### PR TITLE
Default to displaying results of just last build

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -3,13 +3,12 @@
 """Converts one (or several) .ninja_log files into chrome's about:tracing format
 
 Usage:
-    rm $BUILDDIR/.ninja_log && ninja -C $BUILDDIR
+    ninja -C $BUILDDIR
     ninjatracing $BUILDDIR/.ninja_log > trace.json
-
-(If you don't have time for a clean build, at least run
-`ninja -C $BUILDDIR -t recompact` first.)"""
+"""
 
 import json
+import optparse
 import sys
 
 
@@ -21,15 +20,22 @@ class Target:
         self.targets = []
 
 
-def read_targets(log):
+def read_targets(log, show_all):
     """Reads all targets from .ninja_log file |log_file|, sorted by start
     time"""
     header = log.readline()
     assert header == "# ninja log v5\n", \
            "unrecognized ninja log version %r" % header
     targets = {}
+    last_end_seen = 0
     for line in log:
         start, end, _, name, cmdhash = line.strip().split('\t') # Ignore restat.
+        if not show_all and int(end) < last_end_seen:
+            # An earlier time stamp means that this step is the first in a new
+            # build, possibly an incremental build. Throw away the previous data
+            # so that this new build will be displayed independently.
+            targets = {}
+        last_end_seen = int(end)
         targets.setdefault(cmdhash, Target(start, end)).targets.append(name)
     return sorted(targets.values(), key=lambda job: job.start)
 
@@ -49,11 +55,11 @@ class Threads:
         return len(self.workers) - 1
 
 
-def log_to_dicts(log, pid):
+def log_to_dicts(log, pid, show_all):
     """Reads a file-like object |log| containing a .ninja_log, and yields one
     about:tracing dict per command found in the log."""
     threads = Threads()
-    for target in read_targets(log):
+    for target in read_targets(log, show_all):
         yield {
             'name': '%0s' % ', '.join(target.targets), 'cat': 'targets',
             'ph': 'X', 'ts': str(target.start * 1000),
@@ -63,14 +69,26 @@ def log_to_dicts(log, pid):
 
 
 def main(argv):
+    usage = __doc__
+    parser = optparse.OptionParser(usage)
+    parser.add_option('-a', '--showall', action='store_true', dest='showall',
+                      default=False,
+                      help='report on last build step for all outputs. Default '
+                      'is to report just on the last (possibly incremental) '
+                      'build')
+    (options, args) = parser.parse_args()
+
+    if len(args) == 0:
+      print 'Must specify at least one .ninja_log file'
+      parser.print_help()
+      return 1
+
     entries = []
-    for pid, log_file in enumerate(argv):
+    for pid, log_file in enumerate(args):
         with open(log_file, 'r') as log:
-            entries += list(log_to_dicts(log, pid))
+            entries += list(log_to_dicts(log, pid, options.showall))
     json.dump(entries, sys.stdout)
 
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        sys.exit(main(sys.argv[1:]))
-    print __doc__
+    sys.exit(main(sys.argv[1:]))

--- a/ninjatracing_test
+++ b/ninjatracing_test
@@ -14,7 +14,7 @@ class TestNinjaTracing(unittest.TestCase):
         log = StringIO("# ninja log v5\n"
                        "100\t200\t0\tmy_output\tdeadbeef\n"
                        "50\t120\t0\tmy_first_output\t0afef\n")
-        dicts = list(ninjatracing.log_to_dicts(log, 42))
+        dicts = list(ninjatracing.log_to_dicts(log, 42, True))
         expected = [{
                 'name': 'my_first_output', 'cat': 'targets', 'ph': 'X',
                 'ts': '50000', 'dur': '70000', 'pid': '42', 'tid': '0',
@@ -27,13 +27,27 @@ class TestNinjaTracing(unittest.TestCase):
             ]
         self.assertEqual(expected, dicts)
 
+    def test_last_only(self):
+        # Test the behavior without --showall.
+        log = StringIO("# ninja log v5\n"
+                       "100\t200\t0\tmy_output\tdeadbeef\n"
+                       "50\t120\t0\tmy_first_output\t0afef\n")
+        dicts = list(ninjatracing.log_to_dicts(log, 42, False))
+        expected = [{
+                'name': 'my_first_output', 'cat': 'targets', 'ph': 'X',
+                'ts': '50000', 'dur': '70000', 'pid': '42', 'tid': '0',
+                'args': {}
+                },
+            ]
+        self.assertEqual(expected, dicts)
+
     def test_multiple_outputs(self):
         # Both lines here have the same command hash and the same start
         # and end times, meaning they were produced by the same command.
         log = StringIO("# ninja log v5\n"
                        "100\t200\t0\toutput\tdeadbeef\n"
                        "100\t200\t0\tother_output\tdeadbeef\n")
-        dicts = list(ninjatracing.log_to_dicts(log, 42))
+        dicts = list(ninjatracing.log_to_dicts(log, 42, True))
         expected = [{
                 'name': 'output, other_output', 'cat': 'targets', 'ph': 'X',
                 'ts': '100000', 'dur': '100000', 'pid': '42', 'tid': '0',


### PR DESCRIPTION
This change modifies ninjatracing so that by default it just displays
the timing information from the last build. When multiple builds have
been done this is generally more useful. If the .ninja_log file only
includes data from one build then this makes no difference.

The --showall (-a) switch was added to allow the old behavior to be
requested.

This resolves issue #3.