### PR TITLE
Add reference to trace2html to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Idea from Nick Carter, initial implementation from Richard Smith.
     (When using --showall, ideally rm $BUILDDIR/.ninja_log and do a clean build.
     If you don't have time for a clean build, at least run
     `ninja -C $BUILDDIR -t recompact` first to remove no-longer-built targets.)
+
+    The results can be converted from .json format to .html format, for easier
+    loading into about:tracing, using trace2html from:
+    https://github.com/catapult-project/catapult/blob/master/tracing/bin/trace2html


### PR DESCRIPTION
Pretty self explanatory change. I only weakly understand github pull requests so I may be generating more history than is justified. If so I can always refork and redo the change.

I want this change purely so that the next time I need trace2html I will have an easy to find reference to it.
