### PR TITLE
Change sort order to know blocking task

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -49,6 +49,7 @@ def read_targets(log, show_all):
             # so that this new build will be displayed independently.
             targets = {}
         last_end_seen = int(end)
+        start, end = -int(end), -int(start)
         targets.setdefault(cmdhash, Target(start, end)).targets.append(name)
     return sorted(targets.values(), key=lambda job: job.start)
 
@@ -75,7 +76,7 @@ def log_to_dicts(log, pid, show_all):
     for target in read_targets(log, show_all):
         yield {
             'name': '%0s' % ', '.join(target.targets), 'cat': 'targets',
-            'ph': 'X', 'ts': str(target.start * 1000),
+            'ph': 'X', 'ts': str(-target.end * 1000),
             'dur': str((target.end - target.start) * 1000),
             'pid': str(pid), 'tid': str(threads.alloc(target)), 'args': {},
             }


### PR DESCRIPTION
This PR changes order of task sorting so that we can know which task is blocking another tasks easily.

* without this patch
![without this patch](https://user-images.githubusercontent.com/2410354/60672916-80dedd00-9eb1-11e9-961e-51e855120142.png)

* with this patch
![with this patch](https://user-images.githubusercontent.com/2410354/60672949-8fc58f80-9eb1-11e9-8c29-78ddc7962be0.png)
