### PR TITLE
Skip header line in newer ninja logs

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -23,6 +23,7 @@ Usage:
 from __future__ import print_function
 import json
 import optparse
+import re
 import sys
 
 
@@ -38,8 +39,14 @@ def read_targets(log, show_all):
     """Reads all targets from .ninja_log file |log_file|, sorted by start
     time"""
     header = log.readline()
-    assert header == "# ninja log v5\n", \
-           "unrecognized ninja log version %r" % header
+    m = re.search(r'^# ninja log v(\d+)\n$', header)
+    assert m, "unrecognized ninja log version %r" % header
+    version = int(m.group(1))
+    assert 5 <= version <= 6, "unsupported ninja log version %d" % version
+    if version == 6:
+        # Skip header line
+        next(log)
+
     targets = {}
     last_end_seen = 0
     for line in log:


### PR DESCRIPTION
Hello,

This fixes ninjatracing for use with ninja after this change https://github.com/ninja-build/ninja/commit/cfd0bd3007b291df505f8c45083453310142d681 

Depends on https://github.com/ninja-build/ninja/pull/1662

Though alternatively we could just skip all lines starting with `#` if you prefer. I don't expect many more changes in ninja log format, so more strict approach was chosen. 