### PR TITLE
Fix fields which should be numbers instead of strings.

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -83,9 +83,9 @@ def log_to_dicts(log, pid, show_all):
     for target in read_targets(log, show_all):
         yield {
             'name': '%0s' % ', '.join(target.targets), 'cat': 'targets',
-            'ph': 'X', 'ts': str(target.start * 1000),
-            'dur': str((target.end - target.start) * 1000),
-            'pid': str(pid), 'tid': str(threads.alloc(target)), 'args': {},
+            'ph': 'X', 'ts': (target.start * 1000),
+            'dur': ((target.end - target.start) * 1000),
+            'pid': pid, 'tid': threads.alloc(target), 'args': {},
             }
 
 

--- a/ninjatracing_test
+++ b/ninjatracing_test
@@ -30,11 +30,11 @@ class TestNinjaTracing(unittest.TestCase):
         dicts = list(ninjatracing.log_to_dicts(log, 42, True))
         expected = [{
                 'name': 'my_output', 'cat': 'targets', 'ph': 'X',
-                'ts': '100000', 'dur': '100000', 'pid': '42', 'tid': '0',
+                'ts': 100000, 'dur': 100000, 'pid': 42, 'tid': 0,
                 'args': {}
                 }, {
                 'name': 'my_first_output', 'cat': 'targets', 'ph': 'X',
-                'ts': '50000', 'dur': '70000', 'pid': '42', 'tid': '1',
+                'ts': 50000, 'dur': 70000, 'pid': 42, 'tid': 1,
                 'args': {}
                 },
             ]
@@ -48,7 +48,7 @@ class TestNinjaTracing(unittest.TestCase):
         dicts = list(ninjatracing.log_to_dicts(log, 42, False))
         expected = [{
                 'name': 'my_first_output', 'cat': 'targets', 'ph': 'X',
-                'ts': '50000', 'dur': '70000', 'pid': '42', 'tid': '0',
+                'ts': 50000, 'dur': 70000, 'pid': 42, 'tid': 0,
                 'args': {}
                 },
             ]
@@ -63,7 +63,7 @@ class TestNinjaTracing(unittest.TestCase):
         dicts = list(ninjatracing.log_to_dicts(log, 42, True))
         expected = [{
                 'name': 'output, other_output', 'cat': 'targets', 'ph': 'X',
-                'ts': '100000', 'dur': '100000', 'pid': '42', 'tid': '0',
+                'ts': 100000, 'dur': 100000, 'pid': 42, 'tid': 0,
                 'args': {}
                 },
             ]


### PR DESCRIPTION
This allows output from ninjatracing to be used in speedscope.
See https://github.com/jlfwong/speedscope/issues/255

Signed-off-by: Edward Lam <e4lam@yahoo.com>