### PR TITLE
Ignore comment lines in log

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -55,6 +55,8 @@ def read_targets(log, show_all):
     targets = {}
     last_end_seen = 0
     for line in log:
+        if line.startswith('#'):
+            continue
         start, end, _, name, cmdhash = line.strip().split('\t') # Ignore restat.
         if not show_all and int(end) < last_end_seen:
             # An earlier time stamp means that this step is the first in a new

--- a/ninjatracing_test
+++ b/ninjatracing_test
@@ -86,5 +86,25 @@ class TestNinjaTracing(unittest.TestCase):
             ]
         self.assertEqual(expected, dicts)
 
+    def test_comments(self):
+        log = StringIO("# ninja log v5\n"
+                       "#\n"
+                       "100\t200\t0\tmy_output\tdeadbeef\n"
+                       "# 100\t666\t0\tignored_output\tdeadbeef\n"
+                       "50\t120\t0\tmy_first_output\t0afef\n"
+                       "# lastline")
+        dicts = list(ninjatracing.log_to_dicts(log, 42, {'showall': True}))
+        expected = [{
+                'name': 'my_output', 'cat': 'targets', 'ph': 'X',
+                'ts': 100000, 'dur': 100000, 'pid': 42, 'tid': 0,
+                'args': {}
+                }, {
+                'name': 'my_first_output', 'cat': 'targets', 'ph': 'X',
+                'ts': 50000, 'dur': 70000, 'pid': 42, 'tid': 1,
+                'args': {}
+                },
+            ]
+        self.assertEqual(expected, dicts)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`ninjatracing` should ignore any comment line in the ninja log.

See ninja-build issue [1492](https://github.com/ninja-build/ninja/issues/1492).