### PR TITLE
Ignore ill-formed trace events

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -86,6 +86,10 @@ def read_events(trace, options):
     """Reads all events from time-trace json file |trace|."""
     trace_data = json.load(trace)
 
+    # Ignore unrelated JSON files.
+    if 'traceEvents' not in trace_data:
+        return []
+
     def include_event(event, options):
         """Only include events if they are complete events, are longer than
         granularity, and are not totals."""

--- a/ninjatracing_test
+++ b/ninjatracing_test
@@ -86,6 +86,10 @@ class TestNinjaTracing(unittest.TestCase):
             ]
         self.assertEqual(expected, dicts)
 
+        invalid_trace = StringIO('{ "someRandomField": {} }')
+        events = ninjatracing.read_events(invalid_trace, {})
+        self.assertEqual(0, len(events))
+
     def test_comments(self):
         log = StringIO("# ninja log v5\n"
                        "#\n"


### PR DESCRIPTION
I was using this tool against time traces generated in LLVM. The tool picked up a non-trace JSON file
(tools/clang/lib/Tooling/ASTNodeAPI.json, in case you wonder) and bailed out with an exception.
This patch fixes this issue by checking the format of the trace event JSON to make sure it has the 'traceEvents' field before moving on.