### PR TITLE
Add infrastructure for packaging as a wheel file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+
+# Common IDE folders
+.idea/
+.vscode/

--- a/ninjatracing
+++ b/ninjatracing
@@ -156,7 +156,7 @@ def log_to_dicts(log, pid, options):
                 yield time_trace
 
 
-def main(argv):
+def main():
     usage = __doc__
     parser = optparse.OptionParser(usage)
     parser.add_option('-a', '--showall', action='store_true', dest='showall',
@@ -187,4 +187,4 @@ def main(argv):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ninjatracing"
+version = "0.1.0"
+requires-python = ">=3.7"
+authors = [
+  {name = "Nico Weber", email = "thakis@chromium.org"},
+]
+maintainers = [
+  {name = "Nico Weber", email = "thakis@chromium.org"},
+]
+description = "Convert .ninja_log files to chrome's about:tracing format."
+readme = "README.md"
+license = {file = "LICENSE"}
+keywords = ["ninja", "C++", "clang"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python"
+]
+
+[project.urls]
+Repository = "https://github.com/nico/ninjatracing"
+"Bug Tracker" = "https://github.com/nico/ninjatracing/issues"
+
+[project.scripts]
+ninjatracing = "ninjatracing:main"


### PR DESCRIPTION
Add a pyproject.toml file so that this project can be packaged as a wheel file and hopefully uploaded to PyPI.

Addresses https://github.com/nico/ninjatracing/issues/32. Uploading this project to PyPI would also be helpful for me, I am giving a [talk at cppcon](https://cppcon2024.sched.com/event/1gZf4/why-is-my-build-so-slow-compilation-profiling-and-visualization) this year and will be mentioning this repository.