### PR TITLE
Ninja log v7

### DIFF
--- a/ninjatracing
+++ b/ninjatracing
@@ -46,7 +46,7 @@ def read_targets(log, show_all):
     m = re.search(r'^# ninja log v(\d+)\n$', header)
     assert m, "unrecognized ninja log version %r" % header
     version = int(m.group(1))
-    assert 5 <= version <= 6, "unsupported ninja log version %d" % version
+    assert 5 <= version <= 7, "unsupported ninja log version %d" % version
 
     targets = {}
     last_end_seen = 0

--- a/ninjatracing
+++ b/ninjatracing
@@ -47,9 +47,6 @@ def read_targets(log, show_all):
     assert m, "unrecognized ninja log version %r" % header
     version = int(m.group(1))
     assert 5 <= version <= 6, "unsupported ninja log version %d" % version
-    if version == 6:
-        # Skip header line
-        next(log)
 
     targets = {}
     last_end_seen = 0


### PR DESCRIPTION
Ninja v13.0 has incremented to Ninja log version to 7. From what I can tell their are no incompatible format changes and ninjatracing is working fine with this version.

I also removed version 6 logic to skip a header line. This change in Ninja log was [reverted](https://github.com/ninja-build/ninja/commit/97c5949ffeb4ec84cec1290c118cf34aa0e503e4) before Ninja log 6 was released and there was a specific [request to revert the ninjatracting change](https://github.com/ninja-build/ninja/pull/1662#issuecomment-546920054) that seems to have been missed.